### PR TITLE
Use different exit status code for errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ Release <%= Time.now %>
 <% end -%>
 ```
 
+Errors and exit statuses
+------------------------
+
+### No pull requests to be released
+
+exit status is 1.
+
+### Failed to create a new pull request
+
+exit status is 2.
+
+### Failed to update a pull request
+
+exit status is 3.
+
 Author
 ------
 

--- a/bin/git-pr-release
+++ b/bin/git-pr-release
@@ -324,7 +324,7 @@ if create_mode
   )
   unless created_pr
     say 'Failed to create a new pull request', :error
-    exit 1
+    exit 2
   end
   pr_title, pr_body = build_pr_title_and_body created_pr, merged_prs
   release_pr = created_pr
@@ -343,7 +343,7 @@ updated_pull_request = client.update_pull_request(
 
 unless updated_pull_request
   say 'Failed to update a pull request', :error
-  exit 1
+  exit 3
 end
 
 say "#{create_mode ? 'Created' : 'Updated'} pull request: #{updated_pull_request.rels[:html].href}", :notice


### PR DESCRIPTION
Hi, thank you for creating useful tool.

I'd like to introduce different exit status codes for errors.

Now git-pr-release always exit with status code 1 if some error happens.
We run git-pr-release from Jenkins job, so if "No pull requests to be released", the build marks as failure.

It'd be nice if we can distinguish the reason of error from wrapper script - imagine this shell script is put as "Build shell script" text area of Jenkins job configuration page.

```bash
#!/bin/bash

echo $(git-pr-release)
if [ $? == 1 ]
then
    # We don't regard "No pull requests to be released" as failure
    exit 0
else
    # Otherwise don't overwrite exit status
    exit $?
fi
```