### PR TITLE
Implement feature to add labels to a release-PR.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ Release <%= Time.now %>
 <% end -%>
 ```
 
+### `pr-release.labels`
+
+The labels list for adding to pull requests created.
+This value should be comma-separated strings.
+
+If not specified, any labels will not be added for PRs.
+
+
 Errors and exit statuses
 ------------------------
 
@@ -74,6 +82,10 @@ exit status is 2.
 ### Failed to update a pull request
 
 exit status is 3.
+
+### Failed to add labels
+
+exit status is 4.
 
 Author
 ------

--- a/bin/git-pr-release
+++ b/bin/git-pr-release
@@ -346,5 +346,18 @@ unless updated_pull_request
   exit 3
 end
 
+labels = git_config('labels')
+unless labels.nil?
+  labels = labels.split(',')
+  labeled_pull_request = client.add_labels_to_an_issue(
+    repository, release_pr.number, labels
+  )
+  
+  unless labeled_pull_request
+    say 'Failed to add labels to a pull request', :error
+    exit 4
+  end
+end
+
 say "#{create_mode ? 'Created' : 'Updated'} pull request: #{updated_pull_request.rels[:html].href}", :notice
 dump_result_as_json( release_pr, merged_prs ) if @json


### PR DESCRIPTION
I implemented new feature to add specific labels for the release-PR.

Developers can set labels list in .git-pr-release like following way.

```
[pr-release]
	labels = "git-pr-release,New Feature"
```

Please review me. :bow: 