### PR TITLE
Fetch release PR files to use in erb template

### DIFF
--- a/bin/git-pr-release
+++ b/bin/git-pr-release
@@ -111,7 +111,7 @@ Release <%= Time.now %>
 <% end -%>
 ERB
 
-def build_pr_title_and_body(release_pr, merged_prs)
+def build_pr_title_and_body(release_pr, merged_prs, changed_files)
   release_pull_request = target_pull_request = release_pr ? PullRequest.new(release_pr) : DummyPullRequest.new
   merged_pull_requests = pull_requests = merged_prs.map { |pr| PullRequest.new(pr) }
 
@@ -127,10 +127,11 @@ def build_pr_title_and_body(release_pr, merged_prs)
   content.split(/\n/, 2)
 end
 
-def dump_result_as_json(release_pr, merged_prs)
+def dump_result_as_json(release_pr, merged_prs, changed_files)
   puts( {
     :release_pull_request => (release_pr ? PullRequest.new(release_pr) : DummyPullRequest.new).to_hash,
-    :merged_pull_requests => merged_prs.map { |pr| PullRequest.new(pr).to_hash }
+    :merged_pull_requests => merged_prs.map { |pr| PullRequest.new(pr).to_hash },
+    :changed_files        => changed_files.map { |file| file.to_hash }
   }.to_json )
 end
 
@@ -223,6 +224,14 @@ def host_and_repository_and_scheme
   end
 end
 
+# Fetch PR files of specified pull_request
+def pull_request_files(client, pull_request)
+  return [] if pull_request.nil?
+
+  host, repository, scheme = host_and_repository_and_scheme
+  return client.pull_request_files repository, pull_request.number
+end
+
 host, repository, scheme = host_and_repository_and_scheme
 
 if host
@@ -304,14 +313,17 @@ found_release_pr = client.pull_requests(repository).find do |pr|
 end
 create_mode = found_release_pr.nil?
 
+# Fetch changed files of a release PR
+changed_files = pull_request_files(client, found_release_pr)
+
 if @dry_run
-  pr_title, new_body = build_pr_title_and_body found_release_pr, merged_prs
+  pr_title, new_body = build_pr_title_and_body found_release_pr, merged_prs, changed_files
   pr_body = create_mode ? new_body : merge_pr_body(found_release_pr.body, new_body)
 
   say 'Dry-run. Not updating PR', :info
   say pr_title, :notice
   say pr_body, :notice
-  dump_result_as_json( found_release_pr, merged_prs ) if @json
+  dump_result_as_json( found_release_pr, merged_prs, changed_files ) if @json
   exit 0
 end
 
@@ -326,10 +338,11 @@ if create_mode
     say 'Failed to create a new pull request', :error
     exit 2
   end
-  pr_title, pr_body = build_pr_title_and_body created_pr, merged_prs
+  changed_files = pull_request_files(client, created_pr) # Refetch changed files from created_pr
+  pr_title, pr_body = build_pr_title_and_body created_pr, merged_prs, changed_files
   release_pr = created_pr
 else
-  pr_title, new_body = build_pr_title_and_body found_release_pr, merged_prs
+  pr_title, new_body = build_pr_title_and_body found_release_pr, merged_prs, changed_files
   pr_body = merge_pr_body(found_release_pr.body, new_body)
   release_pr = found_release_pr
 end
@@ -360,4 +373,4 @@ if not labels.nil? and not labels.empty?
 end
 
 say "#{create_mode ? 'Created' : 'Updated'} pull request: #{updated_pull_request.rels[:html].href}", :notice
-dump_result_as_json( release_pr, merged_prs ) if @json
+dump_result_as_json( release_pr, merged_prs, changed_files ) if @json


### PR DESCRIPTION
This PR let us use information of changed files in the specified erb template.

I want to add checklists to release flow by changed files information.  For example, if `script/onetime/*` are updated, I want to add a checklist to exec these.  We can do it by the following code if changed files are passed to the erb template.

```
<%- if changed_files.any?{|f| f.filename.match(%r{^script/onetime/}) } -%>
- [ ] `script/onetime/*` are updated
<% changed_files.select{|f| f.filename.match(%r{^script/onetime/}) }.each do |file| %>
    - [ ] Exec `<%= file %>`
<% end %>
<%- end -%>
```