### PR TITLE
[proposal] Create `mention-type` configuration

### DIFF
--- a/bin/git-pr-release
+++ b/bin/git-pr-release
@@ -20,8 +20,7 @@ class PullRequest
   end
 
   def to_checklist_item
-    "- [ ] ##{pr.number} #{pr.title}" +
-       (pr.assignee ? " @#{pr.assignee.login}" : pr.user ? " @#{pr.user.login}" : "")
+    "- [ ] ##{pr.number} #{pr.title}" + mention
   end
 
   def html_link
@@ -30,6 +29,22 @@ class PullRequest
 
   def to_hash
     { :data => @pr.to_hash }
+  end
+
+  def mention
+    mention = case PullRequest.mention_type
+              when 'author'
+                pr.user ? "@#{pr.user.login}" : nil
+              else
+                pr.assignee ? "@#{pr.assignee.login}" : pr.user ? "@#{pr.user.login}" : nil
+              end
+    puts "mention: #{mention}"
+
+    mention ? " #{mention}" : ""
+  end
+
+  def self.mention_type
+    @mention_type ||= (git_config('mention-type') || 'default').tap { |t| puts "mention-type: #{t}" }
   end
 end
 

--- a/bin/git-pr-release
+++ b/bin/git-pr-release
@@ -38,13 +38,12 @@ class PullRequest
               else
                 pr.assignee ? "@#{pr.assignee.login}" : pr.user ? "@#{pr.user.login}" : nil
               end
-    puts "mention: #{mention}"
 
     mention ? " #{mention}" : ""
   end
 
   def self.mention_type
-    @mention_type ||= (git_config('mention-type') || 'default').tap { |t| puts "mention-type: #{t}" }
+    @mention_type ||= (git_config('mention') || 'default')
   end
 end
 


### PR DESCRIPTION
### Motivation
In my project, github pr assignee is just reviewer. So we want to see auther names on release PR's description, instead of assignee names.

### Current
Mentioned users of listed PRs are decided according to following priority.
  1. assignee
  2. author

### Proposal
Add new mode `mention-type: author` that mentions to author.

### Approach
- Add new git config record `pr-release.mention-type`
- When it is set to `author`, git-pr-release write PR auther name for mention

### Usage
```
git config pr-release.mention-type author
```