### PR TITLE
Add --no-fetch option

### DIFF
--- a/bin/git-pr-release
+++ b/bin/git-pr-release
@@ -251,6 +251,9 @@ OptionParser.new do |opts|
   opts.on('--json', 'Show data of target PRs in JSON format') do |v|
     @json = v
   end
+  opts.on('--no-fetch', 'Do not fetch from remote repo before determining target PRs (CI friendly)') do |v|
+    @no_fetch = v
+  end
 end.parse!
 
 ### Set up configuration
@@ -264,7 +267,7 @@ say "Staging branch:    #{staging_branch}", :debug
 
 client = Octokit::Client.new :access_token => obtain_token!
 
-git :remote, 'update', 'origin'
+git :remote, 'update', 'origin' unless @no_fetch
 
 ### Fetch merged PRs
 


### PR DESCRIPTION
We're going to run this script from external CI service (i.e. wercker), which cannot access the private repo with local git command.
So we should or disable `git remote update origin` of this script, or grant access to the repo manually.
The former one seems handy..! This PR implements it!