### PR TITLE
Support `GIT_PR_RELEASE_BRANCH_PRODUCTION` and `GIT_PR_RELEASE_BRANCH…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,16 @@ You can specify this value by `GIT_PR_RELEASE_TOKEN` environment variable.
 
 The branch name that is deployed in production environment.
 
+You can specify this value by `GIT_PR_RELEASE_BRANCH_PRODUCTION` environment variable.
+
 Default value: `master`.
 
 ### `pr-release.branch.staging`
 
 The branch name that the feature branches are merged into and is going to be
 merged into the "production" branch.
+
+You can specify this value by `GIT_PR_RELEASE_BRANCH_STAGING` environment variable.
 
 Default value: `staging`.
 

--- a/bin/git-pr-release
+++ b/bin/git-pr-release
@@ -272,8 +272,8 @@ end.parse!
 
 ### Set up configuration
 
-production_branch  = git_config('branch.production') || 'master'
-staging_branch     = git_config('branch.staging')    || 'staging'
+production_branch = ENV.fetch('GIT_PR_RELEASE_BRANCH_PRODUCTION') { git_config('branch.production') } || 'master'
+staging_branch    = ENV.fetch('GIT_PR_RELEASE_BRANCH_STAGING') { git_config('branch.staging') }       || 'staging'
 
 say "Repository:        #{repository}", :debug
 say "Production branch: #{production_branch}", :debug


### PR DESCRIPTION
…_STAGING` environment variables

This should be useful for a monorepo which contains both iOS app and Android app (so there are two production/release branches). Thanks to this we do not need to rewrite `.git-pr-release` config file to create each-separated release pull requests in a same repository.