### PR TITLE
Support `GIT_PR_RELEASE_TEMPLATE` and `GIT_PR_RELEASE_LABELS` environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The template file path (relative to the workidir top) for pull requests
 created. Its first line is used for the PR title, the rest for the body. This
 is an ERB template.
 
+You can specify this value by `GIT_PR_RELEASE_TEMPLATE` environment variable.
+
 If not specified, the content below is used as the template (embedded in the code):
 
 ```erb
@@ -68,6 +70,8 @@ Release <%= Time.now %>
 
 The labels list for adding to pull requests created.
 This value should be comma-separated strings.
+
+You can specify this value by `GIT_PR_RELEASE_LABELS` environment variable.
 
 If not specified, any labels will not be added for PRs.
 

--- a/bin/git-pr-release
+++ b/bin/git-pr-release
@@ -131,7 +131,7 @@ def build_pr_title_and_body(release_pr, merged_prs, changed_files)
 
   template = DEFAULT_PR_TEMPLATE
 
-  if path = git_config('template')
+  if path = ENV.fetch('GIT_PR_RELEASE_TEMPLATE') { git_config('template') }
     template_path = File.join(git('rev-parse', '--show-toplevel').first.chomp, path)
     template = File.read(template_path)
   end
@@ -376,7 +376,7 @@ unless updated_pull_request
   exit 3
 end
 
-labels = git_config('labels')
+labels = ENV.fetch('GIT_PR_RELEASE_LABELS') { git_config('labels') }
 if not labels.nil? and not labels.empty?
   labels = labels.split(/\s*,\s*/)
   labeled_pull_request = client.add_labels_to_an_issue(


### PR DESCRIPTION
Similar to #23.