### PR TITLE
Fix: released git-pr-release do nothing

### DIFF
--- a/bin/git-pr-release
+++ b/bin/git-pr-release
@@ -409,4 +409,4 @@ def main
   dump_result_as_json( release_pr, merged_prs, changed_files ) if @json
 end
 
-main if $0 == __FILE__
+main if $0 == __FILE__ || $0 == File.join(Gem.dir, "bin", "git-pr-release")


### PR DESCRIPTION
Fix #27

`gem install` puts the executable file in `$GEM_HOME/bin/git-pr-release` .

This executable file makes version switching.

```sh
$ git-pr-release _1.6.0_
```

And the code to version switching is below.

```ruby
load Gem.activate_bin_path('git-pr-release', 'git-pr-release', version)
```

So `if $0 == __FILE__` idiom does not work.