### PR TITLE
Extract logic from bin/git-pr-release

### DIFF
--- a/exe/git-pr-release
+++ b/exe/git-pr-release
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require "git/pr/release"
+
+Git::Pr::Release::CLI.start

--- a/git-pr-release.gemspec
+++ b/git-pr-release.gemspec
@@ -12,7 +12,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/motemen/git-pr-release'
 
   spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 

--- a/lib/git/pr/release.rb
+++ b/lib/git/pr/release.rb
@@ -1,0 +1,8 @@
+require "git/pr/release/cli"
+
+module Git
+  module Pr
+    module Release
+    end
+  end
+end

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -1,0 +1,159 @@
+require 'octokit'
+
+require_relative 'util'
+
+module Git
+  module Pr
+    module Release
+      class CLI
+        def self.start
+          host, repository, scheme = host_and_repository_and_scheme
+
+          if host
+            # GitHub:Enterprise
+            OpenSSL::SSL.const_set :VERIFY_PEER, OpenSSL::SSL::VERIFY_NONE # XXX
+
+            Octokit.configure do |c|
+              c.api_endpoint = "#{scheme}://#{host}/api/v3"
+              c.web_endpoint = "#{scheme}://#{host}/"
+            end
+          end
+
+          OptionParser.new do |opts|
+            opts.on('-n', '--dry-run', 'Do not create/update a PR. Just prints out') do |v|
+              @dry_run = v
+            end
+            opts.on('--json', 'Show data of target PRs in JSON format') do |v|
+              @json = v
+            end
+            opts.on('--no-fetch', 'Do not fetch from remote repo before determining target PRs (CI friendly)') do |v|
+              @no_fetch = v
+            end
+          end.parse!
+
+          ### Set up configuration
+
+          production_branch = ENV.fetch('GIT_PR_RELEASE_BRANCH_PRODUCTION') { git_config('branch.production') } || 'master'
+          staging_branch    = ENV.fetch('GIT_PR_RELEASE_BRANCH_STAGING') { git_config('branch.staging') }       || 'staging'
+
+          say "Repository:        #{repository}", :debug
+          say "Production branch: #{production_branch}", :debug
+          say "Staging branch:    #{staging_branch}", :debug
+
+          client = Octokit::Client.new :access_token => obtain_token!
+
+          git :remote, 'update', 'origin' unless @no_fetch
+
+          ### Fetch merged PRs
+
+          merged_feature_head_sha1s = git(
+            :log, '--merges', '--pretty=format:%P', "origin/#{production_branch}..origin/#{staging_branch}"
+          ).map do |line|
+            main_sha1, feature_sha1 = line.chomp.split /\s+/
+            feature_sha1
+          end
+
+          merged_pull_request_numbers = git('ls-remote', 'origin', 'refs/pull/*/head').map do |line|
+            sha1, ref = line.chomp.split /\s+/
+
+            if merged_feature_head_sha1s.include? sha1
+              if %r<^refs/pull/(\d+)/head$>.match ref
+                pr_number = $1.to_i
+
+                if git('merge-base', sha1, "origin/#{production_branch}").first.chomp == sha1
+                  say "##{pr_number} (#{sha1}) is already merged into #{production_branch}", :debug
+                else
+                  pr_number
+                end
+              else
+                say "Bad pull request head ref format: #{ref}", :warn
+                nil
+              end
+            end
+          end.compact
+
+          if merged_pull_request_numbers.empty?
+            say 'No pull requests to be released', :error
+            exit 1
+          end
+
+          merged_prs = merged_pull_request_numbers.map do |nr|
+            pr = client.pull_request repository, nr
+            say "To be released: ##{pr.number} #{pr.title}", :notice
+            pr
+          end
+
+          ### Create a release PR
+
+          say 'Searching for existing release pull requests...', :info
+          found_release_pr = client.pull_requests(repository).find do |pr|
+            pr.head.ref == staging_branch && pr.base.ref == production_branch
+          end
+          create_mode = found_release_pr.nil?
+
+          # Fetch changed files of a release PR
+          changed_files = pull_request_files(client, found_release_pr)
+
+          if @dry_run
+            pr_title, new_body = build_pr_title_and_body found_release_pr, merged_prs, changed_files
+            pr_body = create_mode ? new_body : merge_pr_body(found_release_pr.body, new_body)
+
+            say 'Dry-run. Not updating PR', :info
+            say pr_title, :notice
+            say pr_body, :notice
+            dump_result_as_json( found_release_pr, merged_prs, changed_files ) if @json
+            exit 0
+          end
+
+          pr_title, pr_body = nil, nil
+          release_pr = nil
+
+          if create_mode
+            created_pr = client.create_pull_request(
+              repository, production_branch, staging_branch, 'Preparing release pull request...', ''
+            )
+            unless created_pr
+              say 'Failed to create a new pull request', :error
+              exit 2
+            end
+            changed_files = pull_request_files(client, created_pr) # Refetch changed files from created_pr
+            pr_title, pr_body = build_pr_title_and_body created_pr, merged_prs, changed_files
+            release_pr = created_pr
+          else
+            pr_title, new_body = build_pr_title_and_body found_release_pr, merged_prs, changed_files
+            pr_body = merge_pr_body(found_release_pr.body, new_body)
+            release_pr = found_release_pr
+          end
+
+          say 'Pull request body:', :debug
+          say pr_body, :debug
+
+          updated_pull_request = client.update_pull_request(
+            repository, release_pr.number, :title => pr_title, :body => pr_body
+          )
+
+          unless updated_pull_request
+            say 'Failed to update a pull request', :error
+            exit 3
+          end
+
+          labels = ENV.fetch('GIT_PR_RELEASE_LABELS') { git_config('labels') }
+          if not labels.nil? and not labels.empty?
+            labels = labels.split(/\s*,\s*/)
+            labeled_pull_request = client.add_labels_to_an_issue(
+              repository, release_pr.number, labels
+            )
+
+            unless labeled_pull_request
+              say 'Failed to add labels to a pull request', :error
+              exit 4
+            end
+          end
+
+          say "#{create_mode ? 'Created' : 'Updated'} pull request: #{updated_pull_request.rels[:html].href}", :notice
+          dump_result_as_json( release_pr, merged_prs, changed_files ) if @json
+        end
+      end
+    end
+  end
+end

--- a/lib/git/pr/release/util.rb
+++ b/lib/git/pr/release/util.rb
@@ -1,14 +1,9 @@
-#!/usr/bin/env ruby
-# -*- coding: utf-8 -*-
-
-require 'uri'
 require 'erb'
+require 'uri'
 require 'open3'
-require 'tmpdir'
-require 'json'
 require 'optparse'
+require 'json'
 
-require 'octokit'
 require 'colorize'
 require 'diff/lcs'
 
@@ -65,6 +60,21 @@ class DummyPullRequest
   end
 end
 
+def host_and_repository_and_scheme
+  @host_and_repository_and_scheme ||= begin
+    remote = git(:config, 'remote.origin.url').first.chomp
+    unless %r(^\w+://) === remote
+      remote = "ssh://#{remote.sub(':', '/')}"
+    end
+
+    remote_url = URI.parse(remote)
+    repository = remote_url.path.sub(%r(^/), '').sub(/\.git$/, '')
+
+    host = remote_url.host == 'github.com' ? nil : remote_url.host
+    [ host, repository, remote_url.scheme === 'http' ? 'http' : 'https' ]
+  end
+end
+
 def say(message, level)
   color = case level
     when :trace
@@ -95,7 +105,6 @@ def git(*command)
   end
   out.each_line
 end
-
 
 def git_config(key)
   host, _ = host_and_repository_and_scheme()
@@ -238,21 +247,6 @@ def request_authorization(client, two_factor_code)
   auth
 end
 
-def host_and_repository_and_scheme
-  @host_and_repository_and_scheme ||= begin
-    remote = git(:config, 'remote.origin.url').first.chomp
-    unless %r(^\w+://) === remote
-      remote = "ssh://#{remote.sub(':', '/')}"
-    end
-
-    remote_url = URI.parse(remote)
-    repository = remote_url.path.sub(%r(^/), '').sub(/\.git$/, '')
-
-    host = remote_url.host == 'github.com' ? nil : remote_url.host
-    [ host, repository, remote_url.scheme === 'http' ? 'http' : 'https' ]
-  end
-end
-
 # Fetch PR files of specified pull_request
 def pull_request_files(client, pull_request)
   return [] if pull_request.nil?
@@ -260,153 +254,3 @@ def pull_request_files(client, pull_request)
   host, repository, scheme = host_and_repository_and_scheme
   return client.pull_request_files repository, pull_request.number
 end
-
-def main
-  host, repository, scheme = host_and_repository_and_scheme
-
-  if host
-    # GitHub:Enterprise
-    OpenSSL::SSL.const_set :VERIFY_PEER, OpenSSL::SSL::VERIFY_NONE # XXX
-
-    Octokit.configure do |c|
-      c.api_endpoint = "#{scheme}://#{host}/api/v3"
-      c.web_endpoint = "#{scheme}://#{host}/"
-    end
-  end
-
-  OptionParser.new do |opts|
-    opts.on('-n', '--dry-run', 'Do not create/update a PR. Just prints out') do |v|
-      @dry_run = v
-    end
-    opts.on('--json', 'Show data of target PRs in JSON format') do |v|
-      @json = v
-    end
-    opts.on('--no-fetch', 'Do not fetch from remote repo before determining target PRs (CI friendly)') do |v|
-      @no_fetch = v
-    end
-  end.parse!
-
-  ### Set up configuration
-
-  production_branch = ENV.fetch('GIT_PR_RELEASE_BRANCH_PRODUCTION') { git_config('branch.production') } || 'master'
-  staging_branch    = ENV.fetch('GIT_PR_RELEASE_BRANCH_STAGING') { git_config('branch.staging') }       || 'staging'
-
-  say "Repository:        #{repository}", :debug
-  say "Production branch: #{production_branch}", :debug
-  say "Staging branch:    #{staging_branch}", :debug
-
-  client = Octokit::Client.new :access_token => obtain_token!
-
-  git :remote, 'update', 'origin' unless @no_fetch
-
-  ### Fetch merged PRs
-
-  merged_feature_head_sha1s = git(
-    :log, '--merges', '--pretty=format:%P', "origin/#{production_branch}..origin/#{staging_branch}"
-  ).map do |line|
-    main_sha1, feature_sha1 = line.chomp.split /\s+/
-    feature_sha1
-  end
-
-  merged_pull_request_numbers = git('ls-remote', 'origin', 'refs/pull/*/head').map do |line|
-    sha1, ref = line.chomp.split /\s+/
-
-    if merged_feature_head_sha1s.include? sha1
-      if %r<^refs/pull/(\d+)/head$>.match ref
-        pr_number = $1.to_i
-
-        if git('merge-base', sha1, "origin/#{production_branch}").first.chomp == sha1
-          say "##{pr_number} (#{sha1}) is already merged into #{production_branch}", :debug
-        else
-          pr_number
-        end
-      else
-        say "Bad pull request head ref format: #{ref}", :warn
-        nil
-      end
-    end
-  end.compact
-
-  if merged_pull_request_numbers.empty?
-    say 'No pull requests to be released', :error
-    exit 1
-  end
-
-  merged_prs = merged_pull_request_numbers.map do |nr|
-    pr = client.pull_request repository, nr
-    say "To be released: ##{pr.number} #{pr.title}", :notice
-    pr
-  end
-
-  ### Create a release PR
-
-  say 'Searching for existing release pull requests...', :info
-  found_release_pr = client.pull_requests(repository).find do |pr|
-    pr.head.ref == staging_branch && pr.base.ref == production_branch
-  end
-  create_mode = found_release_pr.nil?
-
-  # Fetch changed files of a release PR
-  changed_files = pull_request_files(client, found_release_pr)
-
-  if @dry_run
-    pr_title, new_body = build_pr_title_and_body found_release_pr, merged_prs, changed_files
-    pr_body = create_mode ? new_body : merge_pr_body(found_release_pr.body, new_body)
-
-    say 'Dry-run. Not updating PR', :info
-    say pr_title, :notice
-    say pr_body, :notice
-    dump_result_as_json( found_release_pr, merged_prs, changed_files ) if @json
-    exit 0
-  end
-
-  pr_title, pr_body = nil, nil
-  release_pr = nil
-
-  if create_mode
-    created_pr = client.create_pull_request(
-      repository, production_branch, staging_branch, 'Preparing release pull request...', ''
-    )
-    unless created_pr
-      say 'Failed to create a new pull request', :error
-      exit 2
-    end
-    changed_files = pull_request_files(client, created_pr) # Refetch changed files from created_pr
-    pr_title, pr_body = build_pr_title_and_body created_pr, merged_prs, changed_files
-    release_pr = created_pr
-  else
-    pr_title, new_body = build_pr_title_and_body found_release_pr, merged_prs, changed_files
-    pr_body = merge_pr_body(found_release_pr.body, new_body)
-    release_pr = found_release_pr
-  end
-
-  say 'Pull request body:', :debug
-  say pr_body, :debug
-
-  updated_pull_request = client.update_pull_request(
-    repository, release_pr.number, :title => pr_title, :body => pr_body
-  )
-
-  unless updated_pull_request
-    say 'Failed to update a pull request', :error
-    exit 3
-  end
-
-  labels = ENV.fetch('GIT_PR_RELEASE_LABELS') { git_config('labels') }
-  if not labels.nil? and not labels.empty?
-    labels = labels.split(/\s*,\s*/)
-    labeled_pull_request = client.add_labels_to_an_issue(
-      repository, release_pr.number, labels
-    )
-
-    unless labeled_pull_request
-      say 'Failed to add labels to a pull request', :error
-      exit 4
-    end
-  end
-
-  say "#{create_mode ? 'Created' : 'Updated'} pull request: #{updated_pull_request.rels[:html].href}", :notice
-  dump_result_as_json( release_pr, merged_prs, changed_files ) if @json
-end
-
-main if $0 == __FILE__ || $0 == File.join(Gem.dir, "bin", "git-pr-release")

--- a/spec/git/pr/release_spec.rb
+++ b/spec/git/pr/release_spec.rb
@@ -1,6 +1,4 @@
-load File.expand_path("../bin/git-pr-release", __dir__)
-
-RSpec.describe "git-pr-release" do
+RSpec.describe Git::Pr::Release do
   before do
     Timecop.freeze(Time.parse("2019-02-20 22:58:35"))
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "timecop"
 require "yaml"
+require "git/pr/release"
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
Ref: https://github.com/motemen/git-pr-release/issues/29

### Overview

I also got the same issue as https://github.com/motemen/git-pr-release/issues/29. (Our CI server uses rbenv.)

```rb
main if $0 == __FILE__ || $0 == File.join(Gem.dir, "bin", "git-pr-release")
```

I tried to fix this code, but at the end, I also have come to the same conclusion with @hkurokawa.

>So I am wondering if there might be no way to tell apart script loading from script execution (as rbenv loads the script to run).

I think this is one of the ways to fix current situation. My motivation is just to make this script work properly. Basically I tried to not change any logic. 

### Tested as below

```
gem build git-pr-release.gemspec
gem uninstall git-pr-release
gem install /path/to/git-pr-release/git-pr-release-0.8.0.gem
git-pr-release
```