### PR TITLE
Compare only basename instead of full path to execute main

### DIFF
--- a/bin/git-pr-release
+++ b/bin/git-pr-release
@@ -409,4 +409,4 @@ def main
   dump_result_as_json( release_pr, merged_prs, changed_files ) if @json
 end
 
-main if $0 == __FILE__ || $0 == File.join(Gem.dir, "bin", "git-pr-release")
+main if File.basename($0) == File.basename(__FILE__)


### PR DESCRIPTION
I fixes #29 and tested it with my rbenv environment.
