### PR TITLE
Fetch changed files as many as possible

### DIFF
--- a/lib/git/pr/release/util.rb
+++ b/lib/git/pr/release/util.rb
@@ -201,7 +201,12 @@ ERB
           return [] if pull_request.nil?
 
           host, repository, scheme = host_and_repository_and_scheme
-          return client.pull_request_files repository, pull_request.number
+
+          # Fetch files as many as possible
+          client.auto_paginate = true
+          files = client.pull_request_files repository, pull_request.number
+          client.auto_paginate = false
+          return files
         end
       end
     end


### PR DESCRIPTION
List pull requests files API in Github API returns 30 items by default.  So we cannot fetch all changed files if release pull request is large.

- https://developer.github.com/v3/#pagination
- https://developer.github.com/v3/pulls/#list-pull-requests-files

This PR fix to fetch changed files as many as possible