### PR TITLE
Refactor CLI

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -109,7 +109,7 @@ module Git
           create_mode = found_release_pr.nil?
 
           # Fetch changed files of a release PR
-          changed_files = pull_request_files(client, found_release_pr)
+          changed_files = pull_request_files(found_release_pr)
 
           if @dry_run
             pr_title, new_body = build_pr_title_and_body found_release_pr, merged_prs, changed_files
@@ -162,7 +162,7 @@ module Git
         end
 
         def build_and_merge_pr_title_and_body(release_pr, merged_prs)
-          changed_files = pull_request_files(client, release_pr)
+          changed_files = pull_request_files(release_pr)
           old_body = release_pr.body
           pr_title, new_body = build_pr_title_and_body(release_pr, merged_prs, changed_files)
 
@@ -200,6 +200,17 @@ module Git
           end
 
           return 0
+        end
+
+        # Fetch PR files of specified pull_request
+        def pull_request_files(pull_request)
+          return [] if pull_request.nil?
+
+          # Fetch files as many as possible
+          client.auto_paginate = true
+          files = client.pull_request_files repository, pull_request.number
+          client.auto_paginate = false
+          return files
         end
       end
     end

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -122,16 +122,14 @@ module Git
             return 0
           end
 
-          release_pr = nil
-
-          if create_mode
-            release_pr = prepare_release_pr
-            unless release_pr
-              say 'Failed to create a new pull request', :error
-              return 2
-            end
-          else
-            release_pr = found_release_pr
+          release_pr = if create_mode
+                         prepare_release_pr
+                       else
+                         found_release_pr
+                       end
+          unless release_pr
+            say 'Failed to create a new pull request', :error
+            return 2
           end
 
           pr_title, pr_body = build_and_merge_pr_title_and_body(release_pr, merged_prs)

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -6,8 +6,12 @@ module Git
     module Release
       class CLI
         include Git::Pr::Release::Util
-        extend Git::Pr::Release::Util
+
         def self.start
+          self.new.start
+        end
+
+        def start
           host, repository, scheme = host_and_repository_and_scheme
 
           if host
@@ -153,7 +157,7 @@ module Git
           dump_result_as_json( release_pr, merged_prs, changed_files ) if @json
         end
 
-        def self.client
+        def client
           @client ||= Octokit::Client.new :access_token => obtain_token!
         end
       end

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -109,7 +109,11 @@ module Git
           create_mode = found_release_pr.nil?
 
           # Fetch changed files of a release PR
-          changed_files = pull_request_files(found_release_pr)
+          changed_files = if create_mode
+                            []
+                          else
+                            pull_request_files(found_release_pr)
+                          end
 
           if @dry_run
             pr_title, new_body = build_pr_title_and_body found_release_pr, merged_prs, changed_files

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -105,10 +105,7 @@ module Git
         end
 
         def create_release_pr(merged_prs)
-          say 'Searching for existing release pull requests...', :info
-          found_release_pr = client.pull_requests(repository).find do |pr|
-            pr.head.ref == staging_branch && pr.base.ref == production_branch
-          end
+          found_release_pr = detect_existing_release_pr
           create_mode = found_release_pr.nil?
 
           # Fetch changed files of a release PR
@@ -164,6 +161,13 @@ module Git
           dump_result_as_json( release_pr, merged_prs, changed_files ) if @json
 
           return 0
+        end
+
+        def detect_existing_release_pr
+          say 'Searching for existing release pull requests...', :info
+          client.pull_requests(repository).find do |pr|
+            pr.head.ref == staging_branch && pr.base.ref == production_branch
+          end
         end
 
         def set_labels_to_release_pr(release_pr)

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -139,8 +139,6 @@ module Git
 
           update_release_pr(release_pr, pr_title, pr_body)
 
-          set_labels_to_release_pr(release_pr)
-
           say "#{create_mode ? 'Created' : 'Updated'} pull request: #{release_pr.rels[:html].href}", :notice
           dump_result_as_json( release_pr, merged_prs, changed_files ) if @json
         end
@@ -173,14 +171,12 @@ module Git
           client.update_pull_request(
             repository, release_pr.number, :title => pr_title, :body => pr_body
           )
-        end
 
-        def set_labels_to_release_pr(release_pr)
-          return if labels.empty?
-
-          client.add_labels_to_an_issue(
-            repository, release_pr.number, labels
-          )
+          unless labels.empty?
+            client.add_labels_to_an_issue(
+              repository, release_pr.number, labels
+            )
+          end
         end
 
         # Fetch PR files of specified pull_request

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -31,6 +31,10 @@ module Git
 
           ### Fetch merged PRs
           merged_prs = fetch_merged_prs
+          if merged_prs.empty?
+            say 'No pull requests to be released', :error
+            return 1
+          end
 
           ### Create a release PR
 
@@ -158,11 +162,6 @@ module Git
               end
             end
           end.compact
-
-          if merged_pull_request_numbers.empty?
-            say 'No pull requests to be released', :error
-            return 1
-          end
 
           merged_prs = merged_pull_request_numbers.map do |nr|
             pr = client.pull_request repository, nr

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -168,16 +168,16 @@ module Git
 
         def set_labels_to_release_pr(release_pr)
           labels = ENV.fetch('GIT_PR_RELEASE_LABELS') { git_config('labels') }
-          if not labels.nil? and not labels.empty?
-            labels = labels.split(/\s*,\s*/)
-            labeled_pull_request = client.add_labels_to_an_issue(
-              repository, release_pr.number, labels
-            )
+          return 0 if labels.nil? || labels.empty?
 
-            unless labeled_pull_request
-              say 'Failed to add labels to a pull request', :error
-              return 4
-            end
+          labels = labels.split(/\s*,\s*/)
+          labeled_pull_request = client.add_labels_to_an_issue(
+            repository, release_pr.number, labels
+          )
+
+          unless labeled_pull_request
+            say 'Failed to add labels to a pull request', :error
+            return 4
           end
 
           return 0

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -157,6 +157,16 @@ module Git
             return 3
           end
 
+          exit_code = set_labels_to_release_pr(release_pr)
+          return exit_code if exit_code != 0
+
+          say "#{create_mode ? 'Created' : 'Updated'} pull request: #{updated_pull_request.rels[:html].href}", :notice
+          dump_result_as_json( release_pr, merged_prs, changed_files ) if @json
+
+          return 0
+        end
+
+        def set_labels_to_release_pr(release_pr)
           labels = ENV.fetch('GIT_PR_RELEASE_LABELS') { git_config('labels') }
           if not labels.nil? and not labels.empty?
             labels = labels.split(/\s*,\s*/)
@@ -169,9 +179,6 @@ module Git
               return 4
             end
           end
-
-          say "#{create_mode ? 'Created' : 'Updated'} pull request: #{updated_pull_request.rels[:html].href}", :notice
-          dump_result_as_json( release_pr, merged_prs, changed_files ) if @json
 
           return 0
         end

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -6,7 +6,7 @@ module Git
     module Release
       class CLI
         include Git::Pr::Release::Util
-        attr_reader :repository, :production_branch, :staging_branch
+        attr_reader :repository, :production_branch, :staging_branch, :template_path
 
         def self.start
           result = self.new.start
@@ -60,10 +60,12 @@ module Git
 
           @production_branch = ENV.fetch('GIT_PR_RELEASE_BRANCH_PRODUCTION') { git_config('branch.production') } || 'master'
           @staging_branch    = ENV.fetch('GIT_PR_RELEASE_BRANCH_STAGING') { git_config('branch.staging') }       || 'staging'
+          @template_path     = ENV.fetch('GIT_PR_RELEASE_TEMPLATE') { git_config('template') }
 
           say "Repository:        #{repository}", :debug
           say "Production branch: #{production_branch}", :debug
           say "Staging branch:    #{staging_branch}", :debug
+          say "Template path:     #{template_path}", :debug
         end
 
         def fetch_merged_prs
@@ -155,7 +157,7 @@ module Git
         def build_and_merge_pr_title_and_body(release_pr, merged_prs, changed_files)
           # release_pr is nil when dry_run && create_mode
           old_body = release_pr ? release_pr.body : ""
-          pr_title, new_body = build_pr_title_and_body(release_pr, merged_prs, changed_files)
+          pr_title, new_body = build_pr_title_and_body(release_pr, merged_prs, changed_files, template_path)
 
           [pr_title, merge_pr_body(old_body, new_body)]
         end

--- a/lib/git/pr/release/util.rb
+++ b/lib/git/pr/release/util.rb
@@ -195,19 +195,6 @@ ERB
 
           auth
         end
-
-        # Fetch PR files of specified pull_request
-        def pull_request_files(client, pull_request)
-          return [] if pull_request.nil?
-
-          host, repository, scheme = host_and_repository_and_scheme
-
-          # Fetch files as many as possible
-          client.auto_paginate = true
-          files = client.pull_request_files repository, pull_request.number
-          client.auto_paginate = false
-          return files
-        end
       end
     end
   end

--- a/lib/git/pr/release/util.rb
+++ b/lib/git/pr/release/util.rb
@@ -83,16 +83,16 @@ Release <%= Time.now %>
 <% end -%>
 ERB
 
-        def build_pr_title_and_body(release_pr, merged_prs, changed_files)
+        def build_pr_title_and_body(release_pr, merged_prs, changed_files, template_path)
           release_pull_request = target_pull_request = release_pr ? PullRequest.new(release_pr) : DummyPullRequest.new
           merged_pull_requests = pull_requests = merged_prs.map { |pr| PullRequest.new(pr) }
 
-          template = DEFAULT_PR_TEMPLATE
-
-          if path = ENV.fetch('GIT_PR_RELEASE_TEMPLATE') { git_config('template') }
-            template_path = File.join(git('rev-parse', '--show-toplevel').first.chomp, path)
-            template = File.read(template_path)
-          end
+          template = if template_path
+                       template_fullpath = File.join(git('rev-parse', '--show-toplevel').first.chomp, template_path)
+                       File.read(template_path)
+                     else
+                       DEFAULT_PR_TEMPLATE
+                     end
 
           erb = ERB.new template, nil, '-'
           content = erb.result binding

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -17,39 +17,16 @@ RSpec.describe Git::Pr::Release::CLI do
       allow(@cli).to receive(:production_branch) { "master" }
       allow(@cli).to receive(:staging_branch) { "staging" }
 
-      expect(@cli).to receive(:git).with(:remote, "update", "origin") {
-        []
-      }
-
       ### Fetch merged PRs
-      expect(@cli).to receive(:git).with(:log, "--merges", "--pretty=format:%P", "origin/master..origin/staging") {
-        <<~GIT_LOG.each_line
-          ad694b9c2b868e8801f9209f0ad5dd5458c49854 42bd43b80c973c8f348df3521745201be05bf194
-          b620bead10831d2e4e15be392e0a435d3470a0ad 5c977a1827387ac7b7a85c7b827ee119165f1823
-        GIT_LOG
-      }
-      expect(@cli).to receive(:git).with("ls-remote", "origin", "refs/pull/*/head") {
-        <<~GIT_LS_REMOTE.each_line
-          bbcd2a04ef394e91be44c24e93e52fdbca944060        refs/pull/1/head
-          5c977a1827387ac7b7a85c7b827ee119165f1823        refs/pull/3/head
-          42bd43b80c973c8f348df3521745201be05bf194        refs/pull/4/head
-        GIT_LS_REMOTE
-      }
-      expect(@cli).to receive(:git).with("merge-base", "5c977a1827387ac7b7a85c7b827ee119165f1823", "origin/master") {
-        "b620bead10831d2e4e15be392e0a435d3470a0ad".each_line
-      }
-      expect(@cli).to receive(:git).with("merge-base", "42bd43b80c973c8f348df3521745201be05bf194", "origin/master") {
-        "b620bead10831d2e4e15be392e0a435d3470a0ad".each_line
+      expect(@cli).to receive(:fetch_merged_prs) {
+        [
+          Sawyer::Resource.new(@agent, YAML.load_file(file_fixture("pr_3.yml"))),
+          Sawyer::Resource.new(@agent, YAML.load_file(file_fixture("pr_4.yml"))),
+        ]
       }
 
       ### Create a release PR
       client = double(Octokit::Client)
-      expect(client).to receive(:pull_request).with("motemen/git-pr-release", 3) {
-        Sawyer::Resource.new(@agent, YAML.load_file(file_fixture("pr_3.yml")))
-      }
-      expect(client).to receive(:pull_request).with("motemen/git-pr-release", 4) {
-        Sawyer::Resource.new(@agent, YAML.load_file(file_fixture("pr_4.yml")))
-      }
       expect(client).to receive(:pull_requests).with("motemen/git-pr-release") {
         []
       }

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -199,16 +199,7 @@ RSpec.describe Git::Pr::Release::CLI do
       expect(@cli).to receive(:build_pr_title_and_body) {
         [pr_title, pr_body]
       }
-      expect(client).to receive(:update_pull_request).with(
-        "motemen/git-pr-release",
-        1023,
-        {
-          body: pr_body,
-          title: pr_title,
-        }
-      ) {
-        created_pr
-      }
+      expect(@cli).to receive(:update_release_pr).with(created_pr, pr_title, pr_body) { 0 }
       allow(@cli).to receive(:client).with(no_args) {
         client
       }
@@ -219,6 +210,35 @@ RSpec.describe Git::Pr::Release::CLI do
     }
 
     it { is_expected.to eq 0 }
+  end
+
+  describe "#update_release_pr" do
+    subject { @cli.update_release_pr(@release_pr, "PR Title", "PR Body") }
+
+    before {
+      @cli = Git::Pr::Release::CLI.new
+
+      allow(@cli).to receive(:repository) { "motemen/git-pr-release" }
+
+      @release_pr = double(number: 1023)
+
+      @client = double(Octokit::Client)
+      allow(@client).to receive(:update_pull_request) { @release_pr }
+      allow(@cli).to receive(:client) { @client }
+    }
+
+    it {
+      is_expected.to eq 0
+
+      expect(@client).to have_received(:update_pull_request).with(
+        "motemen/git-pr-release",
+        1023,
+        {
+          title: "PR Title",
+          body: "PR Body",
+        }
+      )
+    }
   end
 
   describe "#detect_existing_release_pr" do

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -63,10 +63,6 @@ RSpec.describe Git::Pr::Release::CLI do
         allow(@cli).to receive(:host_and_repository_and_scheme) {
           [nil, "motemen/git-pr-release", "https"]
         }
-        allow(@cli).to receive(:git_config).with("branch.production") { nil }
-        allow(@cli).to receive(:git_config).with("branch.staging") { nil }
-        allow(@cli).to receive(:git_config).with("template") { nil }
-        allow(@cli).to receive(:git_config).with("labels") { nil }
       }
 
       it "configured as default" do
@@ -75,11 +71,11 @@ RSpec.describe Git::Pr::Release::CLI do
         expect(Octokit.api_endpoint).to eq "https://api.github.com/"
         expect(Octokit.web_endpoint).to eq "https://github.com/"
 
-        expect(@cli.instance_variable_get(:@repository)).to eq "motemen/git-pr-release"
-        expect(@cli.instance_variable_get(:@production_branch)).to eq "master"
-        expect(@cli.instance_variable_get(:@staging_branch)).to eq "staging"
-        expect(@cli.instance_variable_get(:@template_path)).to eq nil
-        expect(@cli.instance_variable_get(:@labels)).to eq []
+        expect(@cli.repository).to eq "motemen/git-pr-release"
+        expect(@cli.production_branch).to eq "master"
+        expect(@cli.staging_branch).to eq "staging"
+        expect(@cli.template_path).to eq nil
+        expect(@cli.labels).to eq []
       end
     end
 
@@ -117,8 +113,8 @@ RSpec.describe Git::Pr::Release::CLI do
         it "branches are configured" do
           subject
 
-          expect(@cli.instance_variable_get(:@production_branch)).to eq "prod"
-          expect(@cli.instance_variable_get(:@staging_branch)).to eq "dev"
+          expect(@cli.production_branch).to eq "prod"
+          expect(@cli.staging_branch).to eq "dev"
         end
       end
 
@@ -131,8 +127,8 @@ RSpec.describe Git::Pr::Release::CLI do
         it "branches are configured" do
           subject
 
-          expect(@cli.instance_variable_get(:@production_branch)).to eq "production"
-          expect(@cli.instance_variable_get(:@staging_branch)).to eq "develop"
+          expect(@cli.production_branch).to eq "production"
+          expect(@cli.staging_branch).to eq "develop"
         end
       end
     end

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -86,6 +86,6 @@ RSpec.describe Git::Pr::Release::CLI do
       expect(@cli).to receive(:git_config).with("labels") { nil }
     }
 
-    it { is_expected.to eq nil }
+    it { is_expected.to eq 0 }
   end
 end

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -42,7 +42,11 @@ RSpec.describe Git::Pr::Release::CLI do
   describe "#configure" do
     subject { @cli.configure }
 
-    before { @cli = Git::Pr::Release::CLI.new }
+    before {
+      @cli = Git::Pr::Release::CLI.new
+
+      allow(@cli).to receive(:git_config).with(anything) { nil }
+    }
 
     context "When default" do
       before {
@@ -51,6 +55,7 @@ RSpec.describe Git::Pr::Release::CLI do
         }
         allow(@cli).to receive(:git_config).with("branch.production") { nil }
         allow(@cli).to receive(:git_config).with("branch.staging") { nil }
+        allow(@cli).to receive(:git_config).with("template") { nil }
       }
 
       it "configured as default" do
@@ -62,6 +67,7 @@ RSpec.describe Git::Pr::Release::CLI do
         expect(@cli.instance_variable_get(:@repository)).to eq "motemen/git-pr-release"
         expect(@cli.instance_variable_get(:@production_branch)).to eq "master"
         expect(@cli.instance_variable_get(:@staging_branch)).to eq "staging"
+        expect(@cli.instance_variable_get(:@template_path)).to eq nil
       end
     end
 
@@ -297,6 +303,7 @@ RSpec.describe Git::Pr::Release::CLI do
 
     before {
       @cli = Git::Pr::Release::CLI.new
+      allow(@cli).to receive(:template_path) { nil }
 
       @merged_prs = [double(Sawyer::Resource)]
       allow(@cli).to receive(:build_pr_title_and_body) { ["PR Title", "PR Body"] }
@@ -310,7 +317,7 @@ RSpec.describe Git::Pr::Release::CLI do
       it {
         is_expected.to eq ["PR Title", "Merged Body"]
 
-        expect(@cli).to have_received(:build_pr_title_and_body).with(release_pr, @merged_prs, changed_files)
+        expect(@cli).to have_received(:build_pr_title_and_body).with(release_pr, @merged_prs, changed_files, nil)
         expect(@cli).to have_received(:merge_pr_body).with("Old Body", "PR Body")
       }
     end
@@ -323,7 +330,7 @@ RSpec.describe Git::Pr::Release::CLI do
       it {
         is_expected.to eq ["PR Title", "Merged Body"]
 
-        expect(@cli).to have_received(:build_pr_title_and_body).with(release_pr, @merged_prs, changed_files)
+        expect(@cli).to have_received(:build_pr_title_and_body).with(release_pr, @merged_prs, changed_files, nil)
         expect(@cli).to have_received(:merge_pr_body).with("", "PR Body")
       }
     end

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -252,18 +252,39 @@ RSpec.describe Git::Pr::Release::CLI do
       around do |example|
         original = ENV.to_hash
         begin
-          ENV["GIT_PR_RELEASE_LABELS"] = "release"
+          ENV["GIT_PR_RELEASE_LABELS"] = env_labels
           example.run
         ensure
           ENV.replace(original)
         end
       end
 
-      it "add lavel" do
-        is_expected.to eq 0
-        expect(@client).to have_received(:add_labels_to_an_issue).with(
-          "motemen/git-pr-release", 1023, ["release"]
-        )
+      context "string" do
+        let(:env_labels) { "release" }
+        it "add lavel" do
+          is_expected.to eq 0
+          expect(@client).to have_received(:add_labels_to_an_issue).with(
+            "motemen/git-pr-release", 1023, ["release"]
+          )
+        end
+      end
+
+      context "comma separated string" do
+        let(:env_labels) { "release,release2" }
+        it "add lavel" do
+          is_expected.to eq 0
+          expect(@client).to have_received(:add_labels_to_an_issue).with(
+            "motemen/git-pr-release", 1023, ["release", "release2"]
+          )
+        end
+      end
+
+      context "empty string" do
+        let(:env_labels) { "" }
+        it "do nothing" do
+          is_expected.to eq 0
+          expect(@client).not_to have_received(:add_labels_to_an_issue)
+        end
       end
     end
 

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -144,4 +144,54 @@ RSpec.describe Git::Pr::Release::CLI do
       end
     end
   end
+
+  describe "#fetch_merged_prs" do
+    subject { @cli.fetch_merged_prs }
+
+    before {
+      @cli = Git::Pr::Release::CLI.new
+
+      agent = Sawyer::Agent.new("http://example.com/") do |conn|
+        conn.builder.handlers.delete(Faraday::Adapter::NetHttp)
+        conn.adapter(:test, Faraday::Adapter::Test::Stubs.new)
+      end
+
+      allow(@cli).to receive(:repository) { "motemen/git-pr-release" }
+      allow(@cli).to receive(:production_branch) { "master" }
+      allow(@cli).to receive(:staging_branch) { "staging" }
+
+      expect(@cli).to receive(:git).with(:remote, "update", "origin") {
+        []
+      }
+
+      expect(@cli).to receive(:git).with(:log, "--merges", "--pretty=format:%P", "origin/master..origin/staging") {
+        <<~GIT_LOG.each_line
+          ad694b9c2b868e8801f9209f0ad5dd5458c49854 42bd43b80c973c8f348df3521745201be05bf194
+          b620bead10831d2e4e15be392e0a435d3470a0ad 5c977a1827387ac7b7a85c7b827ee119165f1823
+        GIT_LOG
+      }
+      expect(@cli).to receive(:git).with("ls-remote", "origin", "refs/pull/*/head") {
+        <<~GIT_LS_REMOTE.each_line
+          bbcd2a04ef394e91be44c24e93e52fdbca944060        refs/pull/1/head
+          5c977a1827387ac7b7a85c7b827ee119165f1823        refs/pull/3/head
+          42bd43b80c973c8f348df3521745201be05bf194        refs/pull/4/head
+        GIT_LS_REMOTE
+      }
+      expect(@cli).to receive(:git).with("merge-base", "5c977a1827387ac7b7a85c7b827ee119165f1823", "origin/master") {
+        "b620bead10831d2e4e15be392e0a435d3470a0ad".each_line
+      }
+      expect(@cli).to receive(:git).with("merge-base", "42bd43b80c973c8f348df3521745201be05bf194", "origin/master") {
+        "b620bead10831d2e4e15be392e0a435d3470a0ad".each_line
+      }
+
+      client = double(Octokit::Client)
+      @pr_3 = Sawyer::Resource.new(agent, YAML.load_file(file_fixture("pr_3.yml")))
+      @pr_4 = Sawyer::Resource.new(agent, YAML.load_file(file_fixture("pr_4.yml")))
+      expect(client).to receive(:pull_request).with("motemen/git-pr-release", 3) { @pr_3 }
+      expect(client).to receive(:pull_request).with("motemen/git-pr-release", 4) { @pr_4 }
+      allow(@cli).to receive(:client).with(no_args) { client }
+    }
+
+    it { is_expected.to eq [@pr_3, @pr_4] }
+  end
 end

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -1,8 +1,10 @@
 RSpec.describe Git::Pr::Release::CLI do
-  describe ".start" do
-    subject { Git::Pr::Release::CLI.start }
+  describe "#start" do
+    subject { @cli.start }
 
     before {
+      @cli = Git::Pr::Release::CLI.new
+
       Timecop.freeze(Time.parse("2020-01-04 16:51:09+09:00"))
       @agent = Sawyer::Agent.new("http://example.com/") do |conn|
         conn.builder.handlers.delete(Faraday::Adapter::NetHttp)
@@ -10,33 +12,33 @@ RSpec.describe Git::Pr::Release::CLI do
       end
 
       ### Set up configuration
-      expect(Git::Pr::Release::CLI).to receive(:host_and_repository_and_scheme).with(no_args) {
+      expect(@cli).to receive(:host_and_repository_and_scheme).with(no_args) {
         ["github.com", "motemen/git-pr-release", "https"]
       }
-      expect(Git::Pr::Release::CLI).to receive(:git_config).with("branch.production") { nil }
-      expect(Git::Pr::Release::CLI).to receive(:git_config).with("branch.staging") { nil }
-      expect(Git::Pr::Release::CLI).to receive(:git).with(:remote, "update", "origin") {
+      expect(@cli).to receive(:git_config).with("branch.production") { nil }
+      expect(@cli).to receive(:git_config).with("branch.staging") { nil }
+      expect(@cli).to receive(:git).with(:remote, "update", "origin") {
         []
       }
 
       ### Fetch merged PRs
-      expect(Git::Pr::Release::CLI).to receive(:git).with(:log, "--merges", "--pretty=format:%P", "origin/master..origin/staging") {
+      expect(@cli).to receive(:git).with(:log, "--merges", "--pretty=format:%P", "origin/master..origin/staging") {
         <<~GIT_LOG.each_line
           ad694b9c2b868e8801f9209f0ad5dd5458c49854 42bd43b80c973c8f348df3521745201be05bf194
           b620bead10831d2e4e15be392e0a435d3470a0ad 5c977a1827387ac7b7a85c7b827ee119165f1823
         GIT_LOG
       }
-      expect(Git::Pr::Release::CLI).to receive(:git).with("ls-remote", "origin", "refs/pull/*/head") {
+      expect(@cli).to receive(:git).with("ls-remote", "origin", "refs/pull/*/head") {
         <<~GIT_LS_REMOTE.each_line
           bbcd2a04ef394e91be44c24e93e52fdbca944060        refs/pull/1/head
           5c977a1827387ac7b7a85c7b827ee119165f1823        refs/pull/3/head
           42bd43b80c973c8f348df3521745201be05bf194        refs/pull/4/head
         GIT_LS_REMOTE
       }
-      expect(Git::Pr::Release::CLI).to receive(:git).with("merge-base", "5c977a1827387ac7b7a85c7b827ee119165f1823", "origin/master") {
+      expect(@cli).to receive(:git).with("merge-base", "5c977a1827387ac7b7a85c7b827ee119165f1823", "origin/master") {
         "b620bead10831d2e4e15be392e0a435d3470a0ad".each_line
       }
-      expect(Git::Pr::Release::CLI).to receive(:git).with("merge-base", "42bd43b80c973c8f348df3521745201be05bf194", "origin/master") {
+      expect(@cli).to receive(:git).with("merge-base", "42bd43b80c973c8f348df3521745201be05bf194", "origin/master") {
         "b620bead10831d2e4e15be392e0a435d3470a0ad".each_line
       }
 
@@ -63,7 +65,7 @@ RSpec.describe Git::Pr::Release::CLI do
         - [ ] #3 Provides a creating release pull-request object for template @hakobe
         - [ ] #4 use user who create PR if there is no assignee @motemen
       BODY
-      expect(Git::Pr::Release::CLI).to receive(:build_pr_title_and_body) {
+      expect(@cli).to receive(:build_pr_title_and_body) {
         [pr_title, pr_body]
       }
       expect(client).to receive(:update_pull_request).with(
@@ -76,12 +78,12 @@ RSpec.describe Git::Pr::Release::CLI do
       ) {
         created_pr
       }
-      allow(Git::Pr::Release::CLI).to receive(:client).with(no_args) {
+      allow(@cli).to receive(:client).with(no_args) {
         client
       }
-      expect(Git::Pr::Release::CLI).to receive(:pull_request_files).with(client, nil) { nil }
-      expect(Git::Pr::Release::CLI).to receive(:pull_request_files).with(client, created_pr) { nil }
-      expect(Git::Pr::Release::CLI).to receive(:git_config).with("labels") { nil }
+      expect(@cli).to receive(:pull_request_files).with(client, nil) { nil }
+      expect(@cli).to receive(:pull_request_files).with(client, created_pr) { nil }
+      expect(@cli).to receive(:git_config).with("labels") { nil }
     }
 
     it { is_expected.to eq nil }

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -211,7 +211,6 @@ RSpec.describe Git::Pr::Release::CLI do
       expect(@cli).to have_received(:prepare_release_pr)
       expect(@cli).to have_received(:build_and_merge_pr_title_and_body)
       expect(@cli).to have_received(:update_release_pr).with(@created_pr, @pr_title, @pr_body)
-      expect(@cli).to have_received(:pull_request_files).with(nil)
       expect(@cli).to have_received(:set_labels_to_release_pr).with(@created_pr)
     }
   end

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Git::Pr::Release::CLI do
       end
 
       ### Set up configuration
-      expect(@cli).to receive(:host_and_repository_and_scheme).with(no_args) {
-        ["github.com", "motemen/git-pr-release", "https"]
-      }
-      expect(@cli).to receive(:git_config).with("branch.production") { nil }
-      expect(@cli).to receive(:git_config).with("branch.staging") { nil }
+      expect(@cli).to receive(:configure)
+      allow(@cli).to receive(:repository) { "motemen/git-pr-release" }
+      allow(@cli).to receive(:production_branch) { "master" }
+      allow(@cli).to receive(:staging_branch) { "staging" }
+
       expect(@cli).to receive(:git).with(:remote, "update", "origin") {
         []
       }

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -182,7 +182,8 @@ RSpec.describe Git::Pr::Release::CLI do
       client = double(Octokit::Client)
       created_pr = double(
         number: 1023,
-        rels: { html: double(href: "https://github.com/motemen/git-pr-release/pull/1023") }
+        rels: { html: double(href: "https://github.com/motemen/git-pr-release/pull/1023") },
+        body: "",
       )
       expect(@cli).to receive(:prepare_release_pr) { created_pr }
       pr_title = "Release 2020-01-04 16:51:09 +0900"
@@ -193,7 +194,7 @@ RSpec.describe Git::Pr::Release::CLI do
       expect(@cli).to receive(:build_pr_title_and_body) {
         [pr_title, pr_body]
       }
-      expect(@cli).to receive(:update_release_pr).with(created_pr, pr_title, pr_body) { 0 }
+      expect(@cli).to receive(:update_release_pr).with(created_pr, pr_title, pr_body.chomp) { 0 }
       allow(@cli).to receive(:client).with(no_args) {
         client
       }

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe Git::Pr::Release::CLI do
       }
 
       ### Create a release PR
-      expect(@cli).to receive(:create_release_pr).with([pr_3, pr_4]) {
-        0
-      }
+      expect(@cli).to receive(:create_release_pr).with([pr_3, pr_4])
     }
 
     it { is_expected.to eq 0 }
@@ -178,28 +176,36 @@ RSpec.describe Git::Pr::Release::CLI do
         Sawyer::Resource.new(@agent, YAML.load_file(file_fixture("pr_4.yml"))),
       ]
 
-      expect(@cli).to receive(:detect_existing_release_pr)
-      created_pr = double(
+      allow(@cli).to receive(:detect_existing_release_pr) { nil }
+      @created_pr = double(
         number: 1023,
         rels: { html: double(href: "https://github.com/motemen/git-pr-release/pull/1023") },
         body: "",
       )
-      expect(@cli).to receive(:prepare_release_pr) { created_pr }
-      pr_title = "Release 2020-01-04 16:51:09 +0900"
-      pr_body = <<~BODY.chomp
+      allow(@cli).to receive(:prepare_release_pr) { @created_pr }
+      @pr_title = "Release 2020-01-04 16:51:09 +0900"
+      @pr_body = <<~BODY.chomp
         - [ ] #3 Provides a creating release pull-request object for template @hakobe
         - [ ] #4 use user who create PR if there is no assignee @motemen
       BODY
-      expect(@cli).to receive(:build_and_merge_pr_title_and_body) {
-        [pr_title, pr_body]
+      allow(@cli).to receive(:build_and_merge_pr_title_and_body) {
+        [@pr_title, @pr_body]
       }
-      expect(@cli).to receive(:update_release_pr).with(created_pr, pr_title, pr_body) { 0 }
-      expect(@cli).to receive(:pull_request_files).with(nil) { nil }
-
-      expect(@cli).to receive(:set_labels_to_release_pr).with(created_pr) { 0 }
+      allow(@cli).to receive(:update_release_pr)
+      allow(@cli).to receive(:pull_request_files)
+      allow(@cli).to receive(:set_labels_to_release_pr)
     }
 
-    it { is_expected.to eq 0 }
+    it {
+      subject
+
+      expect(@cli).to have_received(:detect_existing_release_pr)
+      expect(@cli).to have_received(:prepare_release_pr)
+      expect(@cli).to have_received(:build_and_merge_pr_title_and_body)
+      expect(@cli).to have_received(:update_release_pr).with(@created_pr, @pr_title, @pr_body)
+      expect(@cli).to have_received(:pull_request_files).with(nil)
+      expect(@cli).to have_received(:set_labels_to_release_pr).with(@created_pr)
+    }
   end
 
   describe "#prepare_release_pr" do
@@ -270,7 +276,7 @@ RSpec.describe Git::Pr::Release::CLI do
     }
 
     it {
-      is_expected.to eq 0
+      subject
 
       expect(@client).to have_received(:update_pull_request).with(
         "motemen/git-pr-release",
@@ -335,7 +341,7 @@ RSpec.describe Git::Pr::Release::CLI do
       }
 
       it "do nothing" do
-        is_expected.to eq 0
+        subject
         expect(@client).not_to have_received(:add_labels_to_an_issue)
       end
     end
@@ -354,7 +360,7 @@ RSpec.describe Git::Pr::Release::CLI do
       context "string" do
         let(:env_labels) { "release" }
         it "add lavel" do
-          is_expected.to eq 0
+          subject
           expect(@client).to have_received(:add_labels_to_an_issue).with(
             "motemen/git-pr-release", 1023, ["release"]
           )
@@ -364,7 +370,7 @@ RSpec.describe Git::Pr::Release::CLI do
       context "comma separated string" do
         let(:env_labels) { "release,release2" }
         it "add lavel" do
-          is_expected.to eq 0
+          subject
           expect(@client).to have_received(:add_labels_to_an_issue).with(
             "motemen/git-pr-release", 1023, ["release", "release2"]
           )
@@ -374,7 +380,7 @@ RSpec.describe Git::Pr::Release::CLI do
       context "empty string" do
         let(:env_labels) { "" }
         it "do nothing" do
-          is_expected.to eq 0
+          subject
           expect(@client).not_to have_received(:add_labels_to_an_issue)
         end
       end
@@ -386,7 +392,7 @@ RSpec.describe Git::Pr::Release::CLI do
       }
 
       it "add lavel" do
-        is_expected.to eq 0
+        subject
         expect(@client).to have_received(:add_labels_to_an_issue).with(
           "motemen/git-pr-release", 1023, ["release"]
         )

--- a/spec/git/pr/release_spec.rb
+++ b/spec/git/pr/release_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Git::Pr::Release do
   end
 
   describe "#build_pr_title_and_body" do
-    context "without any options" do
+    context "without template_path" do
       it {
-        pr_title, new_body = build_pr_title_and_body(@release_pr, @merged_prs, @changed_files)
+        pr_title, new_body = build_pr_title_and_body(@release_pr, @merged_prs, @changed_files, nil)
         expect(pr_title).to eq "Release 2019-02-20 22:58:35 +0900"
         expect(new_body).to eq <<~MARKDOWN
           - [ ] #3 Provides a creating release pull-request object for template @hakobe
@@ -30,34 +30,12 @@ RSpec.describe Git::Pr::Release do
       }
     end
 
-    context "with ENV" do
-      before {
-        ENV["GIT_PR_RELEASE_TEMPLATE"] = "spec/fixtures/file/template_1.erb"
-      }
-
-      after {
-        ENV["GIT_PR_RELEASE_TEMPLATE"] = nil
-      }
-
+    context "with template_path" do
       it {
-        pr_title, new_body = build_pr_title_and_body(@release_pr, @merged_prs, @changed_files)
+        pr_title, new_body = build_pr_title_and_body(@release_pr, @merged_prs, @changed_files, "spec/fixtures/file/template_1.erb")
         expect(pr_title).to eq "a"
         expect(new_body).to eq <<~MARKDOWN
           b
-        MARKDOWN
-      }
-    end
-
-    context "with git_config template" do
-      before {
-        expect(self).to receive(:git_config).with("template") { "spec/fixtures/file/template_2.erb" }
-      }
-
-      it {
-        pr_title, new_body = build_pr_title_and_body(@release_pr, @merged_prs, @changed_files)
-        expect(pr_title).to eq "c"
-        expect(new_body).to eq <<~MARKDOWN
-          d
         MARKDOWN
       }
     end


### PR DESCRIPTION
* CLI#start as instance method
* Split methods
  - configure
  - fetch_merged_prs
  - create_release_pr
    - detect_existing_release_pr
    - prepare_release_pr
    - build_and_merge_pr_title_and_body
    - update_release_pr
* Move Util#pull_request_files to CLI
* Move evaluating `template_path` by CLI#configure from Util#build_pr_title_and_body
