### PR TITLE
Cannot be found if there are more than 30 pr

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -145,9 +145,12 @@ module Git
 
         def detect_existing_release_pr
           say 'Searching for existing release pull requests...', :info
-          client.pull_requests(repository).find do |pr|
+          client.auto_paginate = true
+          found_release_pr = client.pull_requests(repository).find do |pr|
             pr.head.ref == staging_branch && pr.base.ref == production_branch
           end
+          client.auto_paginate = false
+          return found_release_pr
         end
 
         def prepare_release_pr

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -442,6 +442,7 @@ RSpec.describe Git::Pr::Release::CLI do
 
       @client = double(Octokit::Client)
       allow(@cli).to receive(:client).with(no_args) { @client }
+      allow(@client).to receive(:auto_paginate=)
     }
 
     context "When exists" do


### PR DESCRIPTION
# 事象

openなプルリクの31個以降に git-pr-release で作成したプルリクが存在している場合に、 `client.pull_requests(repository)` でプルリクを見つけることができず、 git-pr-release は新規作成を試みる。しかし、GitHubのAPIは、既に存在しているとのエラーを返す。この状況でも git-pr-release に正常動作してほしい。

# 再現手順

1. master または v1.1.0 の git-pr-release を手元に用意する
1. git-pr-release でプルリクを作成する
1. openなプルリクを30個用意し、 2. のプルリクが31番目以降となるよう押し出す
1. git-pr-release を実行すると、以下のエラーとなる

```
Traceback (most recent call last):
	17: from /usr/local/bin/git-pr-release:23:in `<main>'
	16: from /usr/local/bin/git-pr-release:23:in `load'
	15: from /Library/Ruby/Gems/2.6.0/gems/git-pr-release-1.1.0/exe/git-pr-release:5:in `<top (required)>'
	14: from /Library/Ruby/Gems/2.6.0/gems/git-pr-release-1.1.0/lib/git/pr/release/cli.rb:125:in `start'
	13: from /Library/Ruby/Gems/2.6.0/gems/octokit-4.15.0/lib/octokit/client/pull_requests.rb:59:in `create_pull_request'
	12: from /Library/Ruby/Gems/2.6.0/gems/octokit-4.15.0/lib/octokit/connection.rb:28:in `post'
	11: from /Library/Ruby/Gems/2.6.0/gems/octokit-4.15.0/lib/octokit/connection.rb:156:in `request'
	10: from /Library/Ruby/Gems/2.6.0/gems/sawyer-0.8.2/lib/sawyer/agent.rb:94:in `call'
	 9: from /Library/Ruby/Gems/2.6.0/gems/faraday-1.0.0/lib/faraday/connection.rb:279:in `post'
	 8: from /Library/Ruby/Gems/2.6.0/gems/faraday-1.0.0/lib/faraday/connection.rb:492:in `run_request'
	 7: from /Library/Ruby/Gems/2.6.0/gems/faraday-1.0.0/lib/faraday/rack_builder.rb:153:in `build_response'
	 6: from /Library/Ruby/Gems/2.6.0/gems/faraday-1.0.0/lib/faraday/request/retry.rb:148:in `call'
	 5: from /Library/Ruby/Gems/2.6.0/gems/octokit-4.15.0/lib/octokit/middleware/follow_redirects.rb:61:in `call'
	 4: from /Library/Ruby/Gems/2.6.0/gems/octokit-4.15.0/lib/octokit/middleware/follow_redirects.rb:73:in `perform_with_redirection'
	 3: from /Library/Ruby/Gems/2.6.0/gems/faraday-1.0.0/lib/faraday/response.rb:11:in `call'
	 2: from /Library/Ruby/Gems/2.6.0/gems/faraday-1.0.0/lib/faraday/response.rb:62:in `on_complete'
	 1: from /Library/Ruby/Gems/2.6.0/gems/faraday-1.0.0/lib/faraday/response.rb:12:in `block in call'
/Library/Ruby/Gems/2.6.0/gems/octokit-4.15.0/lib/octokit/response/raise_error.rb:16:in `on_complete': POST https://api.github.com/repos/hogehoge/piyopiyo/pulls: 422 - Validation Failed (Octokit::UnprocessableEntity)
Error summary:
  resource: PullRequest
  code: custom
  message: A pull request already exists for hogehoge:develop. // See: https://developer.github.com/v3/pulls/#create-a-pull-request
```

# 背景

* `client.pull_requests(repository)` は `auto_paginate = false` の場合、openなプルリクを30個のみ取得する
* `client.pull_requests(repository)` は `auto_paginate = true` の場合、openなプルリクを全部取得する
