### PR TITLE
Use API option when detecting existing release PR

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -145,9 +145,7 @@ module Git
 
         def detect_existing_release_pr
           say 'Searching for existing release pull requests...', :info
-          client.pull_requests(repository).find do |pr|
-            pr.head.ref == staging_branch && pr.base.ref == production_branch
-          end
+          client.pull_requests(repository, head: staging_branch, base: production_branch).first
         end
 
         def prepare_release_pr

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -447,8 +447,7 @@ RSpec.describe Git::Pr::Release::CLI do
     context "When exists" do
       before {
         @release_pr = double(head: double(ref: "staging"), base: double(ref: "master"))
-        non_release_pr = double(head: double(ref: "topic"), base: double(ref: "staging"))
-        allow(@client).to receive(:pull_requests) { [non_release_pr, @release_pr] }
+        allow(@client).to receive(:pull_requests) { [@release_pr] }
       }
 
       it { is_expected.to eq @release_pr }


### PR DESCRIPTION
GitHub API has `head` and `base` option.
https://developer.github.com/v3/pulls/#list-pull-requests

Prefer using search criteria to finding in a loop.