### PR TITLE
Fix Errno::ENOENT when finding the specified template

### DIFF
--- a/lib/git/pr/release/util.rb
+++ b/lib/git/pr/release/util.rb
@@ -89,7 +89,7 @@ ERB
 
           template = if template_path
                        template_fullpath = File.join(git('rev-parse', '--show-toplevel').first.chomp, template_path)
-                       File.read(template_path)
+                       File.read(template_fullpath)
                      else
                        DEFAULT_PR_TEMPLATE
                      end


### PR DESCRIPTION
Occurs for monorepo.
I implemented a bug with this commit: 2790e486f3

Fixes #46.